### PR TITLE
Update token perms in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  security-events: read
 
 jobs:
   test-typescript:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ on:
 jobs:
   permissions:
     contents: read
-    pull-requests: write
+    security-events: read
 
   notify-slack:
     runs-on: ubuntu-latest
@@ -32,6 +32,8 @@ jobs:
       - name: PR Dependabot alerts
         id: pr-dependabot-alerts
         uses: mdzhang/pr-dependabot-alerts
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Send Slack Notification
         if:


### PR DESCRIPTION
trying to fix [this thing](https://github.com/mdzhang/pr-dependabot-alerts/actions/runs/13164016188/job/36739639221?pr=4)

`Error: Resource not accessible by integration - https://docs.github.com/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository`